### PR TITLE
Add Team Feature for Captured Monsters

### DIFF
--- a/Content/Players/Trainer.cs
+++ b/Content/Players/Trainer.cs
@@ -1,5 +1,7 @@
 using Monstermon.Content.Items;
 using Monstermon.Content.Types;
+using Monstermon.Content.UI.TeamManager;
+using Terraria;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -7,14 +9,25 @@ public class Trainer : ModPlayer
 {
     public MonsterTeam team;
 
+    public override void Initialize()
+    {
+        team = new MonsterTeam();
+    }
+
     public override void LoadData(TagCompound tag)
     {
         team = tag.Get<MonsterTeam>("team");
+        Mod.Logger.Info($"MONSTERMON : Loaded team : {team}");
     }
 
     public override void SaveData(TagCompound tag)
     {
         tag.Add("team", team);
+    }
+
+    public override void OnEnterWorld()
+    {
+        ModContent.GetInstance<TeamManagerUISystem>().InitializeUI();
     }
 
 }

--- a/Content/Players/Trainer.cs
+++ b/Content/Players/Trainer.cs
@@ -1,0 +1,20 @@
+using Monstermon.Content.Items;
+using Monstermon.Content.Types;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+
+public class Trainer : ModPlayer
+{
+    public MonsterTeam team;
+
+    public override void LoadData(TagCompound tag)
+    {
+        team = tag.Get<MonsterTeam>("team");
+    }
+
+    public override void SaveData(TagCompound tag)
+    {
+        tag.Add("team", team);
+    }
+
+}

--- a/Content/Types/MonsterTeam.cs
+++ b/Content/Types/MonsterTeam.cs
@@ -1,4 +1,6 @@
 using Monstermon.Content.Items;
+using Terraria;
+using Terraria.DataStructures;
 using Terraria.ModLoader.IO;
 
 namespace Monstermon.Content.Types
@@ -6,21 +8,15 @@ namespace Monstermon.Content.Types
     public class MonsterTeam : TagSerializable
     {
         public static readonly System.Func<TagCompound, MonsterTeam> DESERIALIZER = Load;
-        public CapturedMonster?[] slots;
-        public TeamType teamType;
-
-        public MonsterTeam()
-        {
-            slots = new CapturedMonster?[3];
-            teamType = TeamType.OneOneOne;
-        }
+        public Item[] slots = [new(), new(), new(),];
+        public TeamType teamType = TeamType.OneOneOne;
 
         public bool AddMonster(CapturedMonster item, int slotIdx, bool force_swap = false)
         {
             // For now, all monsters take up one slot
             if (slots[slotIdx] is null)
             {
-                slots[slotIdx] = item;
+                slots[slotIdx] = item.Item;
                 return true;
             }
             return false;
@@ -30,6 +26,9 @@ namespace Monstermon.Content.Types
         {
             var team = new MonsterTeam();
             team.teamType = (TeamType)tag.GetInt("type");
+            if (tag.TryGet("slots", out Item[] n_slots))
+                team.slots = n_slots;
+
             return team;
         }
 

--- a/Content/Types/MonsterTeam.cs
+++ b/Content/Types/MonsterTeam.cs
@@ -1,0 +1,53 @@
+using Monstermon.Content.Items;
+using Terraria.ModLoader.IO;
+
+namespace Monstermon.Content.Types
+{
+    public class MonsterTeam : TagSerializable
+    {
+        public static readonly System.Func<TagCompound, MonsterTeam> DESERIALIZER = Load;
+        public CapturedMonster?[] slots;
+        public TeamType teamType;
+
+        public MonsterTeam()
+        {
+            slots = new CapturedMonster?[3];
+            teamType = TeamType.OneOneOne;
+        }
+
+        public bool AddMonster(CapturedMonster item, int slotIdx, bool force_swap = false)
+        {
+            // For now, all monsters take up one slot
+            if (slots[slotIdx] is null)
+            {
+                slots[slotIdx] = item;
+                return true;
+            }
+            return false;
+        }
+
+        public static MonsterTeam Load(TagCompound tag)
+        {
+            var team = new MonsterTeam();
+            team.teamType = (TeamType)tag.GetInt("type");
+            return team;
+        }
+
+        public TagCompound SerializeData()
+        {
+            return new TagCompound
+            {
+                ["slots"] = slots,
+                ["type"] = (int)teamType
+            };
+        }
+    }
+
+    public enum TeamType
+    {
+        OneOneOne,
+        OneTwo,
+        TwoOne,
+        Three
+    }
+}

--- a/Content/UI/TeamManagerUI.cs
+++ b/Content/UI/TeamManagerUI.cs
@@ -1,0 +1,90 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using Terraria;
+using Terraria.GameContent.UI.Elements;
+using Terraria.Localization;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+namespace Monstermon.Content.UI.TeamManager
+{
+    // ExampleUIs visibility is toggled by typing "/coins" in chat (See CoinCommand.cs)
+    // ExampleCoinsUI is a simple UI example showing how to use UIPanel, UIImageButton, and even a custom UIElement
+    // For more info about UI you can check https://github.com/tModLoader/tModLoader/wiki/Basic-UI-Element and https://github.com/tModLoader/tModLoader/wiki/Advanced-guide-to-custom-UI 
+    internal class TeamManagerUIState : UIState
+    {
+        public UIPanel teamManagerPanel;
+        public UIItemSlot slot_ui;
+
+        // In OnInitialize, we place various UIElements onto our UIState (this class).
+        // UIState classes have width and height equal to the full screen, because of this, usually we first define a UIElement that will act as the container for our UI.
+        // We then place various other UIElement onto that container UIElement positioned relative to the container UIElement.
+        public override void OnInitialize()
+        {
+            // Here we define our container UIElement. In DraggableUIPanels, you can see that DraggableUIPanel is a UIPanel with a couple added features.
+            teamManagerPanel = new TeamManagerUIPanel();
+            teamManagerPanel.SetPadding(0);
+            // We need to place this UIElement in relation to its Parent. Later we will be calling `base.Append(teamManagerPanel);`. 
+            // This means that this class, ExampleCoinsUI, will be our Parent. Since ExampleCoinsUI is a UIState, the Left and Top are relative to the top left of the screen.
+            // SetRectangle method help us to set the position and size of UIElement
+            SetRectangle(teamManagerPanel, left: 600f, top: 22f, width: 190f, height: 130f);
+            teamManagerPanel.BackgroundColor = new Color(73, 94, 171);
+
+            UIText displayText = new UIText(Language.GetText("Mods.Monstermon.UI.TeamManager.TeamDisplayText"));
+            displayText.HAlign = 0.5f;
+            displayText.Top.Set(10f, 0);
+            teamManagerPanel.Append(displayText);
+
+            // By properly nesting UIElements, we can position things relatively to each other easily.
+            for (int i = 0; i < 3; i++)
+            {
+                slot_ui = new(Main.LocalPlayer.GetModPlayer<Trainer>().team.slots, i, ItemSlot.Context.InventoryItem);
+                SetRectangle(slot_ui, left: 10f + i * 60f, top: 50f, width: 50f, height: 50f);
+                teamManagerPanel.Append(slot_ui);
+            }
+
+            Append(teamManagerPanel);
+            // As a recap, ExampleCoinsUI is a UIState, meaning it covers the whole screen. We attach teamManagerPanel to ExampleCoinsUI some distance from the top left corner.
+            // We then place playButton, closeButton, and MoneyDisplay onto teamManagerPanel so we can easily place these UIElements relative to teamManagerPanel.
+            // Since teamManagerPanel will move, this proper organization will move playButton, closeButton, and MoneyDisplay properly when teamManagerPanel moves.
+        }
+
+        private void SetRectangle(UIElement uiElement, float left, float top, float width, float height)
+        {
+            uiElement.Left.Set(left, 0f);
+            uiElement.Top.Set(top, 0f);
+            uiElement.Width.Set(width, 0f);
+            uiElement.Height.Set(height, 0f);
+        }
+
+        public void UpdateValue(int pickedUp)
+        {
+
+        }
+    }
+
+    // public class Team : UIElement
+    // {
+    //     public UITeamSlot()
+    //     {
+
+    //     }
+
+    //     /*protected override void DrawSelf(SpriteBatch spriteBatch)
+    //     {
+    //         CalculatedStyle innerDimensions = GetInnerDimensions();
+    //         // Getting top left position of this UIElement
+    //         float shopx = innerDimensions.X;
+    //         float shopy = innerDimensions.Y;
+
+    //         // Drawing first line of coins (current collected coins)
+    //         // CoinsSplit converts the number of copper coins into an array of all types of coins
+    //         DrawCoins(spriteBatch, shopx, shopy, Utils.CoinsSplit(collectedCoins));
+
+    //         // Drawing second line of coins (coins per minute) and text "CPM"
+    //         DrawCoins(spriteBatch, shopx, shopy, Utils.CoinsSplit(GetCoinsPerMinute()), 0, 25);
+    //         Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.ItemStack.Value, "CPM", shopx + (float)(24 * 4), shopy + 25f, Color.White, Color.Black, new Vector2(0.3f), 0.75f);
+    //     }*/
+    // }
+}

--- a/Content/UI/TeamManagerUIPanel.cs
+++ b/Content/UI/TeamManagerUIPanel.cs
@@ -1,0 +1,9 @@
+using Terraria.GameContent.UI.Elements;
+
+namespace Monstermon.Content.UI.TeamManager
+{
+    public class TeamManagerUIPanel : UIPanel
+    {
+
+    }
+}

--- a/Content/UI/TeamManagerUISystem.cs
+++ b/Content/UI/TeamManagerUISystem.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameInput;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+namespace Monstermon.Content.UI.TeamManager
+{
+    [Autoload(Side = ModSide.Client)] // This attribute makes this class only load on a particular side. Naturally this makes sense here since UI should only be a thing clientside. Be wary though that accessing this class serverside will error
+    public class TeamManagerUISystem : ModSystem
+    {
+        private UserInterface playerTeamInterface;
+        internal TeamManagerUIState playerTeamUI;
+
+        // These two methods will set the state of our custom UI, causing it to show or hide
+        public void InitializeUI()
+        {
+            // Activate calls Initialize() on the UIState if not initialized, then calls OnActivate and then calls Activate on every child element
+            playerTeamUI.Activate();
+            playerTeamInterface?.SetState(playerTeamUI);
+        }
+
+        public override void Load()
+        {
+            // Create custom interface which can swap between different UIStates
+            playerTeamInterface = new UserInterface();
+            // Creating custom UIState
+            playerTeamUI = new TeamManagerUIState();
+        }
+
+        public override void UpdateUI(GameTime gameTime)
+        {
+            // Here we call .Update on our custom UI and propagate it to its state and underlying elements
+            if (playerTeamInterface?.CurrentState != null)
+            {
+                playerTeamInterface?.Update(gameTime);
+            }
+        }
+
+        // Adding a custom layer to the vanilla layer list that will call .Draw on your interface if it has a state
+        // Setting the InterfaceScaleType to UI for appropriate UI scaling
+        public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
+        {
+            int mouseTextIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Inventory"));
+            if (mouseTextIndex != -1)
+            {
+                layers.Insert(mouseTextIndex, new LegacyGameInterfaceLayer(
+                    "MonsterAlchemy: Team",
+                    delegate
+                    {
+                        if (playerTeamInterface?.CurrentState != null && Main.playerInventory)
+                        {
+                            playerTeamInterface.Draw(Main.spriteBatch, new GameTime());
+                        }
+                        return true;
+                    },
+                    InterfaceScaleType.UI)
+                );
+            }
+        }
+    }
+}

--- a/Localization/en-US_Mods.Monstermon.hjson
+++ b/Localization/en-US_Mods.Monstermon.hjson
@@ -38,3 +38,5 @@ Buffs: {
 		Description: This monster has been caught by a player.
 	}
 }
+
+UI.TeamManager.TeamDisplayText: Your team


### PR DESCRIPTION
Tackling the problem of creating teams of monsters.

## Goals
- [ ] Monsters can be assembled in a team of up to 3.
  - [x] Adding new monsters to the team
  - [x] Removing a monster
  - [ ] Handle monsters of different sizes
- [x] A Player should have an associated (possibly empty) team.
  - [x] Saving/Loading
  - [x] GUI
  - [ ] Summoning from team

## Changes
- `MonsterTeam` class, representing a team and its management.
- New `ModPlayer` (`Trainer`), with an associated `team` attribute.
