### PR TITLE
Improve the GUI of team management

### DIFF
--- a/Content/Items/CapturedMonster.cs
+++ b/Content/Items/CapturedMonster.cs
@@ -27,6 +27,8 @@ namespace Monstermon.Content.Items
             Item.useAnimation = 20;
             Item.consumable = false;
             Item.UseSound = SoundID.Item4;
+            Item.noUseGraphic = true;
+            Item.noMelee = true;
         }
 
         public override void ModifyTooltips(System.Collections.Generic.List<TooltipLine> tooltips)
@@ -37,11 +39,7 @@ namespace Monstermon.Content.Items
 
         public override bool? UseItem(Player player)
         {
-            // Call back the monster if it has already been summoned
-            if (SummoningSystem.HasSummon(player))
-                return SummoningSystem.RetrieveSummon(player);
-            else
-                return SummoningSystem.SummonMonster(player, this);
+            return false;
         }
 
         // Save data when the item is saved

--- a/Content/Types/MonsterTeam.cs
+++ b/Content/Types/MonsterTeam.cs
@@ -10,6 +10,7 @@ namespace Monstermon.Content.Types
         public static readonly System.Func<TagCompound, MonsterTeam> DESERIALIZER = Load;
         public Item[] slots = [new(), new(), new(),];
         public TeamType teamType = TeamType.OneOneOne;
+        public const int TEAMSIZE = 3;
 
         public bool AddMonster(CapturedMonster item, int slotIdx, bool force_swap = false)
         {
@@ -39,6 +40,23 @@ namespace Monstermon.Content.Types
                 ["slots"] = slots,
                 ["type"] = (int)teamType
             };
+        }
+
+        public bool IsValidSlot(int slotIdx)
+        {
+            switch (teamType)
+            {
+                case TeamType.OneOneOne:
+                    return true;
+                case TeamType.OneTwo:
+                    return slotIdx != 2;
+                case TeamType.TwoOne:
+                    return slotIdx != 1;
+                case TeamType.Three:
+                    return slotIdx == 0;
+                default:
+                    return false;
+            }
         }
     }
 

--- a/Content/Types/MonsterTeam.cs
+++ b/Content/Types/MonsterTeam.cs
@@ -72,6 +72,16 @@ namespace Monstermon.Content.Types
                     return 3;
             }
         }
+
+        public CapturedMonster? FirstMonster()
+        {
+            foreach (var slot in slots)
+            {
+                if (slot.ModItem is CapturedMonster item)
+                    return item;
+            }
+            return null;
+        }
     }
 
     public enum TeamType

--- a/Content/Types/MonsterTeam.cs
+++ b/Content/Types/MonsterTeam.cs
@@ -58,6 +58,20 @@ namespace Monstermon.Content.Types
                     return false;
             }
         }
+
+        public int EffectiveSize()
+        {
+            switch (teamType)
+            {
+                case TeamType.OneTwo:
+                case TeamType.TwoOne:
+                    return 2;
+                case TeamType.Three:
+                    return 1;
+                default:
+                    return 3;
+            }
+        }
     }
 
     public enum TeamType

--- a/Content/UI/TeamManagerUI.cs
+++ b/Content/UI/TeamManagerUI.cs
@@ -137,19 +137,20 @@ namespace Monstermon.Content.UI.TeamManager
         {
             if (base.IsMouseHovering)
             {
+                // Need to be over a slot.
+                if (HoveredSlot() is not int slot)
+                    return;
+
                 Main.LocalPlayer.mouseInterface = true;
-                LeftClick();
+                Hovering(slot);
+                LeftClick(slot);
             }
         }
 
-        private void LeftClick()
+        private void LeftClick(int slot)
         {
             // Need left click.
             if (!(Main.mouseLeftRelease && Main.mouseLeft))
-                return;
-
-            // Need to be over a slot.
-            if (HoveredSlot() is not int slot)
                 return;
 
             // Need not to have a summoned monster to do changes.
@@ -163,6 +164,23 @@ namespace Monstermon.Content.UI.TeamManager
                 return;
 
             Utils.Swap(ref team.slots[slot], ref Main.mouseItem);
+        }
+
+        private void Hovering(int slot)
+        {
+            if (team.slots[slot].ModItem is CapturedMonster cm)
+            {
+                if (SummoningSystem.HasSummon(Main.LocalPlayer))
+                {
+                    UICommon.TooltipMouseText("Cannot change team when a monster is summoned.");
+                }
+                else
+                {
+                    Main.hoverItemName = cm.MonsterName;
+                    var item = cm.Item.Clone();
+                    Main.HoverItem = item;
+                }
+            }
         }
 
         private int? HoveredSlot()

--- a/Content/UI/TeamManagerUI.cs
+++ b/Content/UI/TeamManagerUI.cs
@@ -46,6 +46,7 @@ namespace Monstermon.Content.UI.TeamManager
             teamSlots = new UITeamSlots(Main.LocalPlayer.GetModPlayer<Trainer>().team);
             teamSlots.Top.Set(30f, 0f);
             teamSlots.Left.Set(20f, 0f);
+            teamSlots.HAlign = 0.5f;
 
             teamManagerPanel.Append(teamSlots);
 
@@ -92,6 +93,25 @@ namespace Monstermon.Content.UI.TeamManager
             Vector2 scale = Vector2.One * Main.inventoryScale;
             for (int i = 0; i < MonsterTeam.TEAMSIZE; i++)
             {
+                switch (team.teamType)
+                {
+                    case TeamType.OneOneOne:
+                        scale = Vector2.One * Main.inventoryScale;
+                        break;
+                    case TeamType.OneTwo:
+                        if (i == 1)
+                        {
+                            position += new Vector2(i * 56f, 0f) * Main.inventoryScale;
+                            scale = Vector2.One * Main.inventoryScale;
+                        }
+                        else
+                        {
+                            position += new Vector2(i * 56f, 0f) * Main.inventoryScale;
+                            scale = new Vector2(2f, 1f) * Main.inventoryScale;
+                            i += 1;
+                        }
+                        break;
+                }
                 spriteBatch.Draw(TextureAssets.InventoryBack9.Value, position, null, Main.inventoryBack, 0f, default, scale, SpriteEffects.None, 0f);
                 if (!team.IsValidSlot(i))
                 {
@@ -102,7 +122,7 @@ namespace Monstermon.Content.UI.TeamManager
                     ItemSlot.DrawItemIcon(team.slots[i], 0, spriteBatch, position + scale * (_slotInnerSize / 2f), Main.inventoryScale, 32f, Color.White);
                 }
 
-                position.X += 56f * Main.inventoryScale;
+                position.X += scale.X * _slotInnerSize + _slotMarginSize;
             }
             Main.inventoryScale = _scale;
         }

--- a/Content/UI/TeamManagerUI.cs
+++ b/Content/UI/TeamManagerUI.cs
@@ -11,6 +11,7 @@ using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.UI;
 using Terraria.UI;
 
 namespace Monstermon.Content.UI.TeamManager
@@ -45,9 +46,8 @@ namespace Monstermon.Content.UI.TeamManager
 
             teamSlots = new UITeamSlots(Main.LocalPlayer.GetModPlayer<Trainer>().team);
             teamSlots.Top.Set(30f, 0f);
-            teamSlots.Left.Set(20f, 0f);
+            //teamSlots.Left.Set(20f, 0f);
             teamSlots.HAlign = 0.5f;
-
             teamManagerPanel.Append(teamSlots);
 
             Append(teamManagerPanel);
@@ -60,11 +60,6 @@ namespace Monstermon.Content.UI.TeamManager
             uiElement.Width.Set(width, 0f);
             uiElement.Height.Set(height, 0f);
         }
-
-        public void UpdateValue(int pickedUp)
-        {
-
-        }
     }
 
     public class UITeamSlots : UIElement
@@ -75,42 +70,38 @@ namespace Monstermon.Content.UI.TeamManager
 
         public UITeamSlots(MonsterTeam team)
         {
-            _slotInnerSize = TextureAssets.InventoryBack9.Size().X;
+            _slotInnerSize = TextureAssets.InventoryBack9.Size().X; //should be 48f according to terraria source code
             _slotMarginSize = 56f - _slotInnerSize; // from Terraria source code (Terraria.Main.DrawInventory)
-            Width = new StyleDimension((2 + MonsterTeam.TEAMSIZE) * _slotMarginSize + MonsterTeam.TEAMSIZE * _slotInnerSize, 0f);
+            Width = new StyleDimension((MonsterTeam.TEAMSIZE - 1) * _slotMarginSize + MonsterTeam.TEAMSIZE * _slotInnerSize, 0f);
             Height = new StyleDimension(48f, 0f);
             this.team = team;
         }
 
         protected override void DrawSelf(SpriteBatch spriteBatch)
         {
-            float _scale = Main.inventoryScale;
+            float _previousScale = Main.inventoryScale;
             Main.inventoryScale = 0.85f; // from Terraria code (Terraria.Main.DrawInventory)
 
             HandleSlotLogic();
 
             Vector2 position = GetDimensions().Position();
+            position.X += (3 - team.EffectiveSize()) * (_slotMarginSize / 2f);
+
             Vector2 scale = Vector2.One * Main.inventoryScale;
             for (int i = 0; i < MonsterTeam.TEAMSIZE; i++)
             {
                 switch (team.teamType)
                 {
-                    case TeamType.OneOneOne:
-                        scale = Vector2.One * Main.inventoryScale;
-                        break;
                     case TeamType.OneTwo:
-                        if (i == 1)
-                        {
-                            position += new Vector2(i * 56f, 0f) * Main.inventoryScale;
-                            scale = Vector2.One * Main.inventoryScale;
-                        }
-                        else
-                        {
-                            position += new Vector2(i * 56f, 0f) * Main.inventoryScale;
-                            scale = new Vector2(2f, 1f) * Main.inventoryScale;
-                            i += 1;
-                        }
+                        scale.X = (i == 0 ? 1f : 2f) * Main.inventoryScale;
                         break;
+                    case TeamType.TwoOne:
+                        scale.X = (i == 0 ? 2f : 1f) * Main.inventoryScale;
+                        break;
+                    case TeamType.Three:
+                        scale.X = 3f * Main.inventoryScale;
+                        break;
+
                 }
                 spriteBatch.Draw(TextureAssets.InventoryBack9.Value, position, null, Main.inventoryBack, 0f, default, scale, SpriteEffects.None, 0f);
                 if (!team.IsValidSlot(i))
@@ -122,9 +113,13 @@ namespace Monstermon.Content.UI.TeamManager
                     ItemSlot.DrawItemIcon(team.slots[i], 0, spriteBatch, position + scale * (_slotInnerSize / 2f), Main.inventoryScale, 32f, Color.White);
                 }
 
-                position.X += scale.X * _slotInnerSize + _slotMarginSize;
+                position.X += scale.X * (_slotInnerSize) + _slotMarginSize * Main.inventoryScale;
+                if ((i == 1 && team.teamType is TeamType.OneTwo) || (i == 0 && team.teamType is TeamType.TwoOne))
+                    i++;
+                if (team.teamType is TeamType.Three)
+                    i += 2;
             }
-            Main.inventoryScale = _scale;
+            Main.inventoryScale = _previousScale;
         }
         private void HandleSlotLogic()
         {
@@ -156,16 +151,47 @@ namespace Monstermon.Content.UI.TeamManager
             if (!base.IsMouseHovering)
                 return null;
 
-            Vector2 pos = GetDimensions().Position();
+            Vector2 position = GetDimensions().Position();
+            position.X += (3 - team.EffectiveSize()) * (_slotMarginSize / 2f);
             Vector2 m = Main.MouseScreen;
 
-            if (m.Y < pos.Y || m.Y > pos.Y + GetDimensions().Height * Main.inventoryScale || m.X < pos.X)
+            if (m.Y < position.Y || m.Y > position.Y + GetDimensions().Height * Main.inventoryScale || m.X < position.X || m.X > position.X + GetDimensions().Width * Main.inventoryScale)
                 return null;
 
-            int i = (int)((m.X - pos.X) / ((_slotInnerSize + _slotMarginSize) * Main.inventoryScale));
 
-            if (m.X - pos.X - i * (_slotInnerSize + _slotMarginSize) * Main.inventoryScale < _slotInnerSize * Main.inventoryScale)
-                return i;
+            for (int i = 0; i < MonsterTeam.TEAMSIZE; i++)
+            {
+                float slotWidth;
+                switch (team.teamType)
+                {
+                    case TeamType.OneTwo:
+                        slotWidth = (i == 0 ? 1f : 2f);
+                        break;
+                    case TeamType.TwoOne:
+                        slotWidth = (i == 0 ? 2f : 1f);
+                        break;
+                    case TeamType.Three:
+                        slotWidth = 3f;
+                        break;
+                    default:
+                        slotWidth = 1f;
+                        break;
+
+                }
+                slotWidth *= Main.inventoryScale * _slotInnerSize;
+
+                if (m.X - position.X < slotWidth)
+                {
+                    return i;
+                }
+
+                position.X += slotWidth + _slotMarginSize * Main.inventoryScale;
+                if ((i == 1 && team.teamType is TeamType.OneTwo) || (i == 0 && team.teamType is TeamType.TwoOne))
+                    i++;
+                if (team.teamType is TeamType.Three)
+                    i += 2;
+            }
+
             return null;
         }
     }

--- a/Content/UI/TeamManagerUISystem.cs
+++ b/Content/UI/TeamManagerUISystem.cs
@@ -42,10 +42,10 @@ namespace Monstermon.Content.UI.TeamManager
         // Setting the InterfaceScaleType to UI for appropriate UI scaling
         public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
         {
-            int mouseTextIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Inventory"));
-            if (mouseTextIndex != -1)
+            int inventoryLayerIndex = layers.FindIndex(layer => layer.Name.Equals("Vanilla: Inventory"));
+            if (inventoryLayerIndex != -1)
             {
-                layers.Insert(mouseTextIndex, new LegacyGameInterfaceLayer(
+                layers.Insert(inventoryLayerIndex + 1, new LegacyGameInterfaceLayer(
                     "MonsterAlchemy: Team",
                     delegate
                     {


### PR DESCRIPTION
General improvements to the Team Management UI, most notably introducing a custom slot object to handle variable sized monsters.

## Motivation
The current implementation of the team display uses 3 different `UIItemSlot`. This poses multiple different problems:
1. It is impossible to filter the item being placed, while the team should only accept `CapturedMonster`items.
3. `UIItemSlots` are based on `Item[]`, which in our case is not the best representation of what a monster team is, and makes further evolution of the logic more arduous (eg. larger monsters).

Furthermore, a better place for the summoning of monster would be the team menu, not item use.

## Goals
The goals are the following: 
- Introduce a custom UI element for team management that handles "large monsters".
- Move summoning from the `CapturedMonster` item use to a proper button on the UI.

## Implementation

- [ ] Custom UI
  - [x] Drop/Take items
  - [x] Filter `CapturedMonster` items
  - [x] Show tooltip when hovering
  - [x] Handle different slot sizes
  - [ ] Handle right-click for quick movements (Necessary?)
- [x] Summoning
  - [x] Add a summon/retrieve button
  - [x] Prevent team changes when a monster is summoned
  - [x] Prevent summoning with empty team